### PR TITLE
Make the list of libraries a bit more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,37 +30,39 @@ In order to create a git repository for a new library file a new
 
 ## List
 
-| prefix | name | summary | contact | link |
-| ------ | ---- | ------- | ------- | ---- |
-| squid | squid/squid | Library for squid testing | Martin Kyral <mkyral@redhat.com> | https://github.com/beakerlib/squid/tree/master/squid/ |
-| x509Wrapper | openssl/certgen | Library for creating X.509 certificates for any use |  | https://github.com/beakerlib/openssl/tree/master/certgen/ |
-| RpmSnapshot | rpm/snapshot | RpmSnapshot library | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/rpm/tree/master/snapshot/ |
-| sos | sos/utils | Library with various utility functions for sos tests | David Kutalek <dkutalek@redhat.com> | https://github.com/beakerlib/sos/tree/master/utils/ |
-| rlSE | selinux-policy/common | library(selinux-policy) wrapper | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/selinux-policy/tree/master/common/ |
-| nginx | nginx/nginx | library for testing nginx | Ondrej Ptak <optak@redhat.com> | https://github.com/beakerlib/nginx/tree/master/nginx/ |
-| fwd | firewalld/main | Manage firewalld setup and cleanup | Tomas Dolezal <todoleza@redhat.com> | https://github.com/beakerlib/firewalld/tree/master/main/ |
-| nvr | nvr/nvr | Library allows easily compare NVR of an installed package | Karel Srot <ksrot@redhat.com> | https://github.com/beakerlib/nvr/tree/master/nvr/ |
-| fips | crypto/fips | A set of helpers for FIPS 140 testing | Ondrej Moris <omoris@redhat.com> | https://github.com/beakerlib/crypto/tree/master/fips/ |
-| php | php/utils | Library with various utility functions for php tests | David Kutalek <dkutalek@redhat.com> | https://github.com/beakerlib/php/tree/master/utils/ |
-| distribution_dump__ | distribution/dump | Helpers for dumping files to log | Alois Mahdal <amahdal@redhat.com> | https://github.com/beakerlib/distribution/tree/master/dump/ |
-| opts | distribution/opts | simplified interface to getopts processing | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/opts/ |
-| RpmSnapshotWrapper | distribution/RpmSnapshot | RpmSnapshot library reference | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/RpmSnapshot/ |
-| Log | distribution/Log | More fine-grade logging solution | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/Log/ |
-| tcf | distribution/tcf | Block style coding with ability of skipping parts | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/tcf/ |
-| ConditionalPhasesWrapper | distribution/ConditionalPhases | ConditionalPhases library reference | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/ConditionalPhases/ |
-| testUser | distribution/testUser | This library provides functions for maintaining test users. | Dalibor Pospisil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/testUser/ |
-| distribution_static__ | distribution/static | static file checking | Alois Mahdal <amahdal@redhat.com> | https://github.com/beakerlib/distribution/tree/master/static/ |
-| epelWrapper | distribution/epel | epel library reference | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/epel/ |
-| dpcommon | distribution/dpcommon | A meta library bringing other libraries | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/dpcommon/ |
-| CleanupWrapper | distribution/Cleanup | Cleanup library reference | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/distribution/tree/master/Cleanup/ |
-| LibrariesWrapper | libraries/wrapper | a library wrapper helper | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/libraries/tree/master/wrapper/ |
-| perlsub | perl/subpackage | Library of functions regarding the perl subpackages | Martin Kyral <mkyral@redhat.com> | https://github.com/beakerlib/perl/tree/master/subpackage/ |
-| basic | tuned/basic | Library for tuned | rhack@redhat.com | https://github.com/beakerlib/tuned/tree/master/basic/ |
-| file | example/file | Example of a beakerlib library | Petr Šplíchal <psplicha@redhat.com> | https://github.com/beakerlib/example/tree/master/file/ |
-| http | httpd/http | Basic library for httpd testing | Ondřej Pták <optak@redhat.com> | https://github.com/beakerlib/httpd/tree/master/http/ |
-| postgresql | database/postgresql | Set of basic functions for postgresql | Vaclav Danek <vdanek@redhat.com> | https://github.com/beakerlib/database/tree/master/postgresql/ |
-| mysql | database/mysql | Set of basic functions for mysql | Jakub Heger <jheger@redhat.com> | https://github.com/beakerlib/database/tree/master/mysql/ |
-| mariadb | database/mariadb | Set of basic functions for mariadb | Lukas Zachar <lzachar@redhat.com> | https://github.com/beakerlib/database/tree/master/mariadb/ |
-| epel | epel/epel | EPEL handling | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/epel/tree/master/epel/ |
-| ConditionalPhases | ControlFlow/ConditionalPhases | Implements conditional phases. | Dalibor Pospíšil <dapospis@redhat.com> | https://github.com/beakerlib/ControlFlow/tree/master/ConditionalPhases/ |
-| Cleanup | ControlFlow/Cleanup | Provides function to define cleanup stack which can do its work at any time | Dalibor Pospisil <dapospis@redhat.com> | https://github.com/beakerlib/ControlFlow/tree/master/Cleanup/ |
+| name | summary | contact |
+| ---- | ------- | ---- |
+| [ControlFlow/Cleanup](https://github.com/beakerlib/ControlFlow/tree/master/Cleanup/) | Provides function to define cleanup stack which can do its work at any time | Dalibor Pospisil <dapospis@redhat.com> |
+| [ControlFlow/ConditionalPhases](https://github.com/beakerlib/ControlFlow/tree/master/ConditionalPhases/) | Implements conditional phases. | Dalibor Pospíšil <dapospis@redhat.com> |
+| [crypto/fips](https://github.com/beakerlib/crypto/tree/master/fips/) | A set of helpers for FIPS 140 testing | Ondrej Moris <omoris@redhat.com> |
+| [database/mariadb](https://github.com/beakerlib/database/tree/master/mariadb/) | Set of basic functions for mariadb | Lukas Zachar <lzachar@redhat.com> |
+| [database/mysql](https://github.com/beakerlib/database/tree/master/mysql/) | Set of basic functions for mysql | Jakub Heger <jheger@redhat.com> |
+| [database/postgresql](https://github.com/beakerlib/database/tree/master/postgresql/) | Set of basic functions for postgresql | Vaclav Danek <vdanek@redhat.com> |
+| [distribution/Cleanup](https://github.com/beakerlib/distribution/tree/master/Cleanup/) | Cleanup library reference | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/ConditionalPhases](https://github.com/beakerlib/distribution/tree/master/ConditionalPhases/) | ConditionalPhases library reference | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/dpcommon](https://github.com/beakerlib/distribution/tree/master/dpcommon/) | A meta library bringing other libraries | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/dump](https://github.com/beakerlib/distribution/tree/master/dump/) | Helpers for dumping files to log | Alois Mahdal <amahdal@redhat.com> |
+| [distribution/epel](https://github.com/beakerlib/distribution/tree/master/epel/) | epel library reference | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/Log](https://github.com/beakerlib/distribution/tree/master/Log/) | More fine-grade logging solution | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/opts](https://github.com/beakerlib/distribution/tree/master/opts/) | simplified interface to getopts processing | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/RpmSnapshot](https://github.com/beakerlib/distribution/tree/master/RpmSnapshot/) | RpmSnapshot library reference | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/static](https://github.com/beakerlib/distribution/tree/master/static/) | static file checking | Alois Mahdal <amahdal@redhat.com> |
+| [distribution/tcf](https://github.com/beakerlib/distribution/tree/master/tcf/) | Block style coding with ability of skipping parts | Dalibor Pospíšil <dapospis@redhat.com> |
+| [distribution/testUser](https://github.com/beakerlib/distribution/tree/master/testUser/) | This library provides functions for maintaining test users. | Dalibor Pospisil <dapospis@redhat.com> |
+| [epel/epel](https://github.com/beakerlib/epel/tree/master/epel/) | EPEL handling | Dalibor Pospíšil <dapospis@redhat.com> |
+| [example/file](https://github.com/beakerlib/example/tree/master/file/) | Example of a beakerlib library | Petr Šplíchal <psplicha@redhat.com> |
+| [firewalld/main](https://github.com/beakerlib/firewalld/tree/master/main/) | Manage firewalld setup and cleanup | Tomas Dolezal <todoleza@redhat.com> |
+| [httpd/http](https://github.com/beakerlib/httpd/tree/master/http/) | Basic library for httpd testing | Ondřej Pták <optak@redhat.com> |
+| [libraries/wrapper](https://github.com/beakerlib/libraries/tree/master/wrapper/) | a library wrapper helper | Dalibor Pospíšil <dapospis@redhat.com> |
+| [nginx/nginx](https://github.com/beakerlib/nginx/tree/master/nginx/) | library for testing nginx | Ondrej Ptak <optak@redhat.com> |
+| [nvr/nvr](https://github.com/beakerlib/nvr/tree/master/nvr/) | Library allows easily compare NVR of an installed package | Karel Srot <ksrot@redhat.com> |
+| [openssl/certgen](https://github.com/beakerlib/openssl/tree/master/certgen/) | Library for creating X.509 certificates for any use |  |
+| [perl/subpackage](https://github.com/beakerlib/perl/tree/master/subpackage/) | Library of functions regarding the perl subpackages | Martin Kyral <mkyral@redhat.com> |
+| [php/utils](https://github.com/beakerlib/php/tree/master/utils/) | Library with various utility functions for php tests | David Kutalek <dkutalek@redhat.com> |
+| [rpm/snapshot](https://github.com/beakerlib/rpm/tree/master/snapshot/) | RpmSnapshot library | Dalibor Pospíšil <dapospis@redhat.com> |
+| [rsyslog/basic](https://github.com/beakerlib/rsyslog/tree/master/basic/) | basic functions to support rsyslog | Dalibor Pospíšil <dapospis@redhat.com> |
+| [selinux-policy/common](https://github.com/beakerlib/selinux-policy/tree/master/common/) | library(selinux-policy) wrapper | Dalibor Pospíšil <dapospis@redhat.com> |
+| [sos/utils](https://github.com/beakerlib/sos/tree/master/utils/) | Library with various utility functions for sos tests | David Kutalek <dkutalek@redhat.com> |
+| [squid/squid](https://github.com/beakerlib/squid/tree/master/squid/) | Library for squid testing | Martin Kyral <mkyral@redhat.com> |
+| [tuned/basic](https://github.com/beakerlib/tuned/tree/master/basic/) | Library for tuned | rhack@redhat.com |
+| [wrapper](https://github.com/beakerlib/wrapper/) | a library wrapper helper | Dalibor Pospíšil <dapospis@redhat.com> |

--- a/liblist.sh
+++ b/liblist.sh
@@ -43,19 +43,18 @@ function repoupdate() {
 function generatetable() {
     TmpDir=$(mktemp -d)
     cat libraries/README.md | grep -v '|' > $TmpDir/README.md
-    echo "| prefix | name | summary | contact | link |" >> $TmpDir/README.md
-    echo "| ------ | ---- | ------- | ------- | ---- |" >> $TmpDir/README.md
-    for lib in $(find . -name lib.sh) ; do
+    echo "| name | summary | contact |" >> $TmpDir/README.md
+    echo "| ---- | ------- | ---- |" >> $TmpDir/README.md
+    for lib in $(find . -name lib.sh | sort) ; do
         [ "$lib" = "./test/very/deep/file/lib.sh" ] && continue
         dir=$(echo $lib | sed 's/\/lib.sh//')
         cd $dir
-        prefix=$(grep '# *library-prefix = ' lib.sh | sed 's/.* = //')
         name=$(echo $dir | sed 's/\.\///')
         summary=$(grep '^summary: ' main.fmf | sed 's/summary: //')
         contact=$(grep @ main.fmf | sed 's/.*- //' | sed 's/contact: *//')
         ghuri=$(echo $name | sed 's/\//\/tree\/master\//')
         link="https://github.com/beakerlib/$ghuri/"
-        echo "| $prefix | $name | $summary | $contact | $link |" >> $TmpDir/README.md
+        echo "| [$name]($link) | $summary | $contact |" >> $TmpDir/README.md
         cd - &>/dev/null
     done
     cat $TmpDir/README.md > libraries/README.md


### PR DESCRIPTION
The current table is too wide to be nicely displayed.
Convert the library name to link and remove the prefix.
Also sort the list alphabetically for better searching.